### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ JMAP (JSON Meta Application Protocol) email servers. Built with Deno and using
 the [@htunnicliff/jmap-jam](https://jsr.io/@htunnicliff/jmap-jam) client
 library.
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/wyattjoh-jmap-mcp).
+
 ## Features
 
 ### Email Management Tools


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/wyattjoh-jmap-mcp).