### PR TITLE
fix: add calculateTotal to JMAP query calls for reliable pagination

### DIFF
--- a/src/tools/email.ts
+++ b/src/tools/email.ts
@@ -276,6 +276,7 @@ export function registerEmailTools(
           filter,
           limit: args.limit,
           position: args.position,
+          calculateTotal: true,
           sort: [{ property: "receivedAt", isAscending: false }],
         });
 
@@ -334,6 +335,7 @@ export function registerEmailTools(
           filter,
           limit: args.limit,
           position: args.position,
+          calculateTotal: true,
           sort: [{ property: "sortOrder", isAscending: true }],
         });
 

--- a/src/tools/email_test.ts
+++ b/src/tools/email_test.ts
@@ -229,3 +229,55 @@ Deno.test("search_emails pagination indicates hasMore when results exceed page",
     "Showing 2 of 10 results (position 0\u20131)",
   );
 });
+
+Deno.test("search_emails passes calculateTotal to Email.query", async () => {
+  // deno-lint-ignore no-explicit-any
+  let capturedArgs: any;
+  const { client } = await setup({
+    emailQuery: (args: unknown) => {
+      capturedArgs = args;
+      return Promise.resolve([{
+        ids: ["e1"],
+        total: 1,
+        position: 0,
+        queryState: "qs-1",
+        canCalculateChanges: true,
+      }]);
+    },
+  });
+  await client.callTool({
+    name: "search_emails",
+    arguments: { query: "test" },
+  });
+
+  assertEquals(capturedArgs.calculateTotal, true);
+});
+
+Deno.test("get_mailboxes passes calculateTotal to Mailbox.query", async () => {
+  // deno-lint-ignore no-explicit-any
+  let capturedArgs: any;
+  const jam = createMockJam();
+  // Override Mailbox.query to capture args
+  // deno-lint-ignore no-explicit-any
+  (jam as any).api.Mailbox.query = (args: unknown) => {
+    capturedArgs = args;
+    return Promise.resolve([{ ids: ["m1"], total: 1, position: 0 }]);
+  };
+
+  const server = new McpServer({ name: "test", version: "0.0.1" });
+  registerEmailTools(server, jam as never, "acct-1", false);
+
+  const [clientTransport, serverTransport] = InMemoryTransport
+    .createLinkedPair();
+  await server.connect(serverTransport);
+
+  const client = new Client({ name: "test-client", version: "0.0.1" });
+  await client.connect(clientTransport);
+
+  await client.callTool({
+    name: "get_mailboxes",
+    arguments: {},
+  });
+
+  assertEquals(capturedArgs.calculateTotal, true);
+});


### PR DESCRIPTION
## Summary

- Adds `calculateTotal: true` to `Email/query` and `Mailbox/query` JMAP calls so that `total` is reliably returned by the server
- Fixes `hasMore` pagination field being incorrectly set to `false` after the first page of results
- Adds regression tests verifying `calculateTotal: true` is passed to both query calls

## Problem

Per [RFC 8620 §5.5](https://www.rfc-editor.org/rfc/rfc8620#section-5.5), the JMAP server **MUST omit** the `total` field from query responses when `calculateTotal` is not explicitly set to `true`. Neither `search_emails` nor `get_mailboxes` were setting this flag.

The `hasMore` calculation uses `result.total`:
```typescript
hasMore: result.position + result.ids.length < (result.total || 0)
```

When `total` is `undefined` (the spec-compliant behavior without `calculateTotal`), the `|| 0` fallback makes this evaluate to `position + count < 0`, which is always `false`. This causes the tool to report no more pages exist even when many more results match the query.

Some servers (e.g. FastMail) may return `total` as a courtesy even without `calculateTotal`, which explains why the behavior was inconsistent — the first page might show `hasMore: true` but subsequent pages would not.