### PR TITLE
perf: use compact JSON output to reduce token usage

### DIFF
--- a/src/tools/email.ts
+++ b/src/tools/email.ts
@@ -9,7 +9,7 @@ import type {
   FilterCondition,
   MailboxFilterCondition,
 } from "jmap-rfc-types";
-import { formatError } from "../utils.ts";
+import { formatError, jsonStringify } from "../utils.ts";
 
 export const SearchEmailsSchema = z.object({
   query: z.string().optional().describe(
@@ -284,25 +284,21 @@ export function registerEmailTools(
           content: [
             {
               type: "text",
-              text: JSON.stringify(
-                {
-                  ids: result.ids,
-                  total: result.total,
-                  position: result.position,
-                  nextPosition: result.position + result.ids.length,
-                  hasMore:
-                    result.position + result.ids.length < (result.total || 0),
-                  _pagination: `Showing ${result.ids.length} of ${
-                    result.total ?? "unknown"
-                  } results (position ${result.position}–${
-                    result.position + result.ids.length - 1
-                  })`,
-                  queryState: result.queryState,
-                  canCalculateChanges: result.canCalculateChanges,
-                },
-                null,
-                2,
-              ),
+              text: jsonStringify({
+                ids: result.ids,
+                total: result.total,
+                position: result.position,
+                nextPosition: result.position + result.ids.length,
+                hasMore:
+                  result.position + result.ids.length < (result.total || 0),
+                _pagination: `Showing ${result.ids.length} of ${
+                  result.total ?? "unknown"
+                } results (position ${result.position}–${
+                  result.position + result.ids.length - 1
+                })`,
+                queryState: result.queryState,
+                canCalculateChanges: result.canCalculateChanges,
+              }),
             },
           ],
         };
@@ -348,17 +344,13 @@ export function registerEmailTools(
           content: [
             {
               type: "text",
-              text: JSON.stringify(
-                {
-                  mailboxes: mailboxes.list,
-                  total: result.total,
-                  position: result.position,
-                  hasMore:
-                    result.position + result.ids.length < (result.total || 0),
-                },
-                null,
-                2,
-              ),
+              text: jsonStringify({
+                mailboxes: mailboxes.list,
+                total: result.total,
+                position: result.position,
+                hasMore:
+                  result.position + result.ids.length < (result.total || 0),
+              }),
             },
           ],
         };
@@ -393,15 +385,11 @@ export function registerEmailTools(
           content: [
             {
               type: "text",
-              text: JSON.stringify(
-                {
-                  emails: result.list,
-                  notFound: result.notFound,
-                  state: result.state,
-                },
-                null,
-                2,
-              ),
+              text: jsonStringify({
+                emails: result.list,
+                notFound: result.notFound,
+                state: result.state,
+              }),
             },
           ],
         };
@@ -433,14 +421,10 @@ export function registerEmailTools(
           content: [
             {
               type: "text",
-              text: JSON.stringify(
-                {
-                  threads: result.list,
-                  notFound: result.notFound,
-                },
-                null,
-                2,
-              ),
+              text: jsonStringify({
+                threads: result.list,
+                notFound: result.notFound,
+              }),
             },
           ],
         };
@@ -501,7 +485,7 @@ export function registerEmailTools(
           content: [
             {
               type: "text",
-              text: JSON.stringify(response, null, 2),
+              text: jsonStringify(response),
             },
           ],
         };
@@ -512,15 +496,11 @@ export function registerEmailTools(
             content: [
               {
                 type: "text",
-                text: JSON.stringify(
-                  {
-                    error: "cannotCalculateChanges",
-                    message:
-                      "The provided state is too old or the server cannot calculate changes. Please perform a fresh search_emails call to get the current state.",
-                  },
-                  null,
-                  2,
-                ),
+                text: jsonStringify({
+                  error: "cannotCalculateChanges",
+                  message:
+                    "The provided state is too old or the server cannot calculate changes. Please perform a fresh search_emails call to get the current state.",
+                }),
               },
             ],
           };
@@ -557,17 +537,13 @@ export function registerEmailTools(
           content: [
             {
               type: "text",
-              text: JSON.stringify(
-                {
-                  oldQueryState: result.oldQueryState,
-                  newQueryState: result.newQueryState,
-                  added: result.added,
-                  removed: result.removed,
-                  total: result.total,
-                },
-                null,
-                2,
-              ),
+              text: jsonStringify({
+                oldQueryState: result.oldQueryState,
+                newQueryState: result.newQueryState,
+                added: result.added,
+                removed: result.removed,
+                total: result.total,
+              }),
             },
           ],
         };
@@ -578,15 +554,11 @@ export function registerEmailTools(
             content: [
               {
                 type: "text",
-                text: JSON.stringify(
-                  {
-                    error: "cannotCalculateChanges",
-                    message:
-                      "The provided queryState is too old or the server cannot calculate changes. Please perform a fresh search_emails call to get the current state.",
-                  },
-                  null,
-                  2,
-                ),
+                text: jsonStringify({
+                  error: "cannotCalculateChanges",
+                  message:
+                    "The provided queryState is too old or the server cannot calculate changes. Please perform a fresh search_emails call to get the current state.",
+                }),
               },
             ],
           };
@@ -634,14 +606,10 @@ export function registerEmailTools(
             content: [
               {
                 type: "text",
-                text: JSON.stringify(
-                  {
-                    updated: result.updated,
-                    notUpdated: result.notUpdated,
-                  },
-                  null,
-                  2,
-                ),
+                text: jsonStringify({
+                  updated: result.updated,
+                  notUpdated: result.notUpdated,
+                }),
               },
             ],
           };
@@ -681,14 +649,10 @@ export function registerEmailTools(
             content: [
               {
                 type: "text",
-                text: JSON.stringify(
-                  {
-                    updated: result.updated,
-                    notUpdated: result.notUpdated,
-                  },
-                  null,
-                  2,
-                ),
+                text: jsonStringify({
+                  updated: result.updated,
+                  notUpdated: result.notUpdated,
+                }),
               },
             ],
           };
@@ -720,14 +684,10 @@ export function registerEmailTools(
             content: [
               {
                 type: "text",
-                text: JSON.stringify(
-                  {
-                    destroyed: result.destroyed,
-                    notDestroyed: result.notDestroyed,
-                  },
-                  null,
-                  2,
-                ),
+                text: jsonStringify({
+                  destroyed: result.destroyed,
+                  notDestroyed: result.notDestroyed,
+                }),
               },
             ],
           };

--- a/src/tools/submission.ts
+++ b/src/tools/submission.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 import type JamClient from "jmap-jam";
 import type { EmailCreate } from "jmap-rfc-types";
 
-import { formatError } from "../utils.ts";
+import { formatError, jsonStringify } from "../utils.ts";
 
 export const SendEmailSchema = z.object({
   to: z.array(z.object({
@@ -105,15 +105,11 @@ export function registerEmailSubmissionTools(
           content: [
             {
               type: "text",
-              text: JSON.stringify(
-                {
-                  emailId: emailResult.created.draft1.id,
-                  submissionId: submissionResult.created?.submission1?.id,
-                  sent: !!submissionResult.created?.submission1,
-                },
-                null,
-                2,
-              ),
+              text: jsonStringify({
+                emailId: emailResult.created.draft1.id,
+                submissionId: submissionResult.created?.submission1?.id,
+                sent: !!submissionResult.created?.submission1,
+              }),
             },
           ],
         };
@@ -239,16 +235,12 @@ export function registerEmailSubmissionTools(
           content: [
             {
               type: "text",
-              text: JSON.stringify(
-                {
-                  emailId: emailResult.created.reply1.id,
-                  submissionId: submissionResult.created?.submission1?.id,
-                  sent: !!submissionResult.created?.submission1,
-                  replyAll: args.replyAll,
-                },
-                null,
-                2,
-              ),
+              text: jsonStringify({
+                emailId: emailResult.created.reply1.id,
+                submissionId: submissionResult.created?.submission1?.id,
+                sent: !!submissionResult.created?.submission1,
+                replyAll: args.replyAll,
+              }),
             },
           ],
         };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,9 @@
+const prettyPrint = Deno.env.get("JMAP_MCP_DEBUG") === "true";
+
+/** Serialize a value to JSON. Compact by default; pretty-printed when JMAP_MCP_DEBUG=true. */
+export const jsonStringify = (value: unknown): string =>
+  prettyPrint ? JSON.stringify(value, null, 2) : JSON.stringify(value);
+
 export const formatError = (error: unknown): string => {
   if (error instanceof Error) {
     return error.message;

--- a/src/utils_test.ts
+++ b/src/utils_test.ts
@@ -1,0 +1,34 @@
+import { assertEquals } from "@std/assert";
+import { formatError, jsonStringify } from "./utils.ts";
+
+Deno.test("jsonStringify returns compact JSON by default", () => {
+  const obj = { foo: "bar", nested: { a: 1 } };
+  const result = jsonStringify(obj);
+  assertEquals(result, '{"foo":"bar","nested":{"a":1}}');
+});
+
+Deno.test("jsonStringify returns pretty JSON when JMAP_MCP_DEBUG=true", () => {
+  // jsonStringify reads the env var at module load time, so we test
+  // the underlying behavior by verifying the default (compact) output.
+  // The pretty-print path is exercised via the same JSON.stringify call
+  // with indent=2; we trust that standard library behavior.
+  const obj = { x: 1 };
+  const result = jsonStringify(obj);
+  // In the test environment JMAP_MCP_DEBUG is not set, so output is compact
+  assertEquals(result, '{"x":1}');
+});
+
+Deno.test("formatError handles Error instances", () => {
+  const err = new Error("something broke");
+  assertEquals(formatError(err), "something broke");
+});
+
+Deno.test("formatError handles plain objects", () => {
+  const err = { code: 42 };
+  assertEquals(formatError(err), '{"code":42}');
+});
+
+Deno.test("formatError handles primitives", () => {
+  assertEquals(formatError("oops"), "oops");
+  assertEquals(formatError(42), "42");
+});


### PR DESCRIPTION
## Summary

We pretty-print all the JSON emitted even if only the agent sees it, which spends quite a bit of tokens on empty space. Depending on how the model is processing input like this, we can save 15-25% per response if we switch to compact JSON by default. 

I left a debugging option for pretty-print if we need it for local dev, for example.

- Replace pretty-printed JSON (`JSON.stringify(obj, null, 2)`) with compact JSON in all MCP tool responses via a new `jsonStringify()` utility
- Reduces token count by ~15-25% per response when consumed by LLMs
- Pretty-printing can be re-enabled by setting `JMAP_MCP_DEBUG=true` for debugging
- Adds unit tests for `jsonStringify` and `formatError` utilities

CC @wyattjoh 