### PR TITLE
fix: set fetchTextBodyValues/fetchHTMLBodyValues in Email.get calls

### DIFF
--- a/src/tools/email.ts
+++ b/src/tools/email.ts
@@ -369,15 +369,21 @@ export function registerEmailTools(
 
   server.tool(
     "get_emails",
-    "Get specific emails by their IDs. Use the `properties` parameter to request only what you need — requesting all properties returns large payloads. Recommended property sets: summary: ['id', 'subject', 'from', 'to', 'receivedAt', 'preview', 'keywords', 'mailboxIds'], full read: ['id', 'subject', 'from', 'to', 'cc', 'receivedAt', 'bodyValues', 'textBody', 'htmlBody']. IMPORTANT: to get body content, you must include 'bodyValues' AND at least one of 'textBody' or 'htmlBody' in properties. Returns `state` for incremental sync via get_email_changes.",
+    "Get specific emails by their IDs. Use the `properties` parameter to request only what you need — requesting all properties returns large payloads. Recommended property sets: summary: ['id', 'subject', 'from', 'to', 'receivedAt', 'preview', 'keywords', 'mailboxIds'], full read: ['id', 'subject', 'from', 'to', 'cc', 'receivedAt', 'bodyValues', 'textBody', 'htmlBody']. To get body content, include 'bodyValues' AND at least one of 'textBody' or 'htmlBody' in properties — the server will automatically fetch the corresponding body values. Returns `state` for incremental sync via get_email_changes.",
     GetEmailsSchema.shape,
     async (args: z.infer<typeof GetEmailsSchema>) => {
       try {
+        const props = args.properties;
+        const wantsBody = !props || props.includes("bodyValues");
         const [result] = await jam.api.Email.get(
           {
             accountId,
             ids: args.ids,
-            properties: args.properties,
+            properties: props,
+            fetchTextBodyValues: wantsBody &&
+              (!props || props.includes("textBody")),
+            fetchHTMLBodyValues: wantsBody &&
+              (!props || props.includes("htmlBody")),
           } satisfies GetEmailArguments,
         );
 
@@ -471,11 +477,17 @@ export function registerEmailTools(
             ...changesResult.created,
             ...changesResult.updated,
           ];
+          const props = args.properties;
+          const wantsBody = !props || props.includes("bodyValues");
           const [emailResult] = await jam.api.Email.get(
             {
               accountId,
               ids: idsToFetch,
-              properties: args.properties,
+              properties: props,
+              fetchTextBodyValues: wantsBody &&
+                (!props || props.includes("textBody")),
+              fetchHTMLBodyValues: wantsBody &&
+                (!props || props.includes("htmlBody")),
             } satisfies GetEmailArguments,
           );
           response.emails = emailResult.list;

--- a/src/tools/email_test.ts
+++ b/src/tools/email_test.ts
@@ -99,6 +99,130 @@ Deno.test("get_emails returns state field", async () => {
   assertEquals(parsed.notFound.length, 0);
 });
 
+Deno.test("get_emails sets fetchTextBodyValues when bodyValues and textBody requested", async () => {
+  // deno-lint-ignore no-explicit-any
+  let capturedArgs: any;
+  const { client } = await setup({
+    emailGet: (args: unknown) => {
+      capturedArgs = args;
+      return Promise.resolve([{
+        list: [{ id: "e1", subject: "Test" }],
+        notFound: [],
+        state: "state-123",
+      }]);
+    },
+  });
+  await client.callTool({
+    name: "get_emails",
+    arguments: {
+      ids: ["e1"],
+      properties: ["id", "bodyValues", "textBody"],
+    },
+  });
+
+  assertEquals(capturedArgs.fetchTextBodyValues, true);
+  assertEquals(capturedArgs.fetchHTMLBodyValues, false);
+});
+
+Deno.test("get_emails sets fetchHTMLBodyValues when bodyValues and htmlBody requested", async () => {
+  // deno-lint-ignore no-explicit-any
+  let capturedArgs: any;
+  const { client } = await setup({
+    emailGet: (args: unknown) => {
+      capturedArgs = args;
+      return Promise.resolve([{
+        list: [{ id: "e1", subject: "Test" }],
+        notFound: [],
+        state: "state-123",
+      }]);
+    },
+  });
+  await client.callTool({
+    name: "get_emails",
+    arguments: {
+      ids: ["e1"],
+      properties: ["id", "bodyValues", "htmlBody"],
+    },
+  });
+
+  assertEquals(capturedArgs.fetchTextBodyValues, false);
+  assertEquals(capturedArgs.fetchHTMLBodyValues, true);
+});
+
+Deno.test("get_emails does not set fetch flags when bodyValues not requested", async () => {
+  // deno-lint-ignore no-explicit-any
+  let capturedArgs: any;
+  const { client } = await setup({
+    emailGet: (args: unknown) => {
+      capturedArgs = args;
+      return Promise.resolve([{
+        list: [{ id: "e1", subject: "Test" }],
+        notFound: [],
+        state: "state-123",
+      }]);
+    },
+  });
+  await client.callTool({
+    name: "get_emails",
+    arguments: {
+      ids: ["e1"],
+      properties: ["id", "subject", "textBody"],
+    },
+  });
+
+  assertEquals(capturedArgs.fetchTextBodyValues, false);
+  assertEquals(capturedArgs.fetchHTMLBodyValues, false);
+});
+
+Deno.test("get_emails sets both fetch flags when properties omitted", async () => {
+  // deno-lint-ignore no-explicit-any
+  let capturedArgs: any;
+  const { client } = await setup({
+    emailGet: (args: unknown) => {
+      capturedArgs = args;
+      return Promise.resolve([{
+        list: [{ id: "e1", subject: "Test" }],
+        notFound: [],
+        state: "state-123",
+      }]);
+    },
+  });
+  await client.callTool({
+    name: "get_emails",
+    arguments: { ids: ["e1"] },
+  });
+
+  assertEquals(capturedArgs.fetchTextBodyValues, true);
+  assertEquals(capturedArgs.fetchHTMLBodyValues, true);
+  assertEquals(capturedArgs.properties, undefined);
+});
+
+Deno.test("get_email_changes sets fetch flags when bodyValues in properties", async () => {
+  // deno-lint-ignore no-explicit-any
+  let capturedArgs: any;
+  const { client } = await setup({
+    emailGet: (args: unknown) => {
+      capturedArgs = args;
+      return Promise.resolve([{
+        list: [{ id: "e1", subject: "Test" }],
+        notFound: [],
+        state: "state-200",
+      }]);
+    },
+  });
+  await client.callTool({
+    name: "get_email_changes",
+    arguments: {
+      sinceState: "state-100",
+      fetchEmails: true,
+      properties: ["id", "bodyValues", "textBody", "htmlBody"],
+    },
+  });
+
+  assertEquals(capturedArgs.fetchTextBodyValues, true);
+  assertEquals(capturedArgs.fetchHTMLBodyValues, true);
+});
+
 Deno.test("get_email_changes returns created/updated/destroyed", async () => {
   const { client } = await setup();
   const result = await client.callTool({


### PR DESCRIPTION
## Summary

- **Fixes `bodyValues` always returning `{}` (empty object)** when agents request email body content via `get_emails` or `get_email_changes`
- Automatically sets `fetchTextBodyValues` and `fetchHTMLBodyValues` flags based on the requested properties, as required by JMAP RFC 8621

## Problem

Per [RFC 8621 Section 4.4.4](https://www.rfc-editor.org/rfc/rfc8621.html#section-4.4.4), `Email/get` requires `fetchTextBodyValues: true` and/or `fetchHTMLBodyValues: true` for the `bodyValues` map to be populated. Without these flags, the JMAP server returns `bodyValues: {}` regardless of what properties are requested.

The `jmap-jam` client library already supports these flags in `GetEmailArguments`, but the MCP tool was not passing them through. This caused agents to receive empty body content even when correctly requesting `bodyValues` + `textBody`/`htmlBody` in the properties array.

## Fix

When building the `Email/get` request, the tool now auto-detects which fetch flags to set:

| Properties requested | `fetchTextBodyValues` | `fetchHTMLBodyValues` |
|---|---|---|
| `bodyValues` + `textBody` | `true` | `false` |
| `bodyValues` + `htmlBody` | `false` | `true` |
| `bodyValues` + both | `true` | `true` |
| omitted (all properties) | `true` | `true` |
| no `bodyValues` | `false` | `false` |

Applied to both `get_emails` and `get_email_changes` handlers.